### PR TITLE
Support for varying simulation time parameters

### DIFF
--- a/barmap_simulator.pl
+++ b/barmap_simulator.pl
@@ -10,7 +10,6 @@ use strict;
 use warnings;
 use Carp;
 use Scalar::Util qw(reftype looks_like_number);
-use List::Util qw(all);
 use YAML;
 use vars qw/
   $T0 $T8 $TX $P0 $TINC $SIM_TIMES_FILE $TEMP $EQ @FILES $TREEKIN %ENV

--- a/barmap_simulator.pl
+++ b/barmap_simulator.pl
@@ -12,7 +12,8 @@ use Carp;
 use vars qw/$T0 $T8 $TX $P0 $TINC $TEMP $EQ @FILES $TREEKIN %ENV $RATESUFFIX/;
 
 # defaults for global(s)
-$TREEKIN = "$ENV{HOME}/C/treekin/treekin";
+# $TREEKIN = "$ENV{HOME}/C/treekin/treekin";
+$TREEKIN = 'treekin';
 $T0 = 0.1;
 $T8 = 10;
 $TX = -1;


### PR DESCRIPTION
These patches add support for varying simulation time parameters, i.e., for each input rates file, a separate set of start time (`-t0`), end time (`-t8`), and time increment (`-inc`) parameters may be specified. This is useful, for example, to simulate variable transcription rates during the cotranscriptional folding of an RNA (e.g. due to pause sites).

The feature is implemented as a parameter `-times-file` that takes as argument the path to a YAML file specifying some or all of the times parameters for selected rates files. The values given in the passed simulation times file overwrite the global values set using  the command line arguments like `-t0` (only) for their respective rates file.     An example file is given in the program help (`-h`). 