### PR TITLE
Improved detection of last non-comment line of Treekin output.

### DIFF
--- a/barmap_simulator.pl
+++ b/barmap_simulator.pl
@@ -9,6 +9,8 @@ use File::Basename;
 use strict;
 use warnings;
 use Carp;
+use List::Util qw(all);
+use Scalar::Util qw(looks_like_number);
 use vars qw/$T0 $T8 $TX $P0 $TINC $TEMP $EQ @FILES $TREEKIN %ENV $RATESUFFIX/;
 
 # defaults for global(s)
@@ -227,13 +229,19 @@ sub do_simulation {
     return (-1, undef, undef); 
   }
 
-  # get last line of time course
-  $output[-2] = '#' . $output[-2] if $flag == 1;
-  my $lastline = $output[-2];
+  # get last line of time course not beginning with a '#' (i.e. no comment)
+  my $lastline_index = (grep {$output[$_] !~ /^#/} 0..$#output)[-1];
+  die 'No data found in Treekin output' unless defined $lastline_index;
+  $output[$lastline_index] = '#' . $output[$lastline_index] if $flag == 1;
+  my $lastline = $output[$lastline_index];
 
   $lastline =~ s/^\s+//;
   # extract values from last line of time course
   my @values = split /\s+/, $lastline;
+
+  # check that we found at least two and nothing but numbers.
+  die 'Received invalid last output line from Treekin: ', $lastline
+    unless @values > 1 and all {looks_like_number $_} @values;
 
   my @valuescp = @values;
   shift @valuescp;


### PR DESCRIPTION
BarMap incorrectly takes the *second-to-last* data line emitted by Treekin instead of the *last* one to update the global time. This results in plotting artifacts as shown in the screenshots below.

![treekin_small_times](https://user-images.githubusercontent.com/1579775/70530876-1c0c6a80-1b54-11ea-80d1-c289287155e3.png)

![treekin_small_times_fix](https://user-images.githubusercontent.com/1579775/70530883-1f075b00-1b54-11ea-8953-29e2bd48cbce.png)

According to the authors, this behavior is because older versions of Treekin emitted a comment line (beginning with `#`) as the last line, but newer versions don't do this anymore. This patch makes BarMap choose the last non-comment line to continue the simulation.
