### PR TITLE
Set --feps option of Treekin to -1

### DIFF
--- a/barmap_simulator.pl
+++ b/barmap_simulator.pl
@@ -205,6 +205,7 @@ sub uniq_tuples {
 sub build_command {
   my ($p_zeros, $stop, $file) = @_;
   my $command = "$TREEKIN -m I";
+  $command .= " --feps=-1.0";           # solves some numerical issues
   $command .= " --tinc=$TINC";
   $command .= " --t0=$T0";
   $command .= " --t8=$stop";


### PR DESCRIPTION
Set `--feps` option of Treekin to -1 (i.e., use Lapack's default instead of Treekins default value of 1e-15). This solves crashes due to numerical issues with some instances. 

Hard-coding this setting is probably debatable. I never had any problems with Lapack's default value (in contrast to the Treekin default of 1e-15). Should I add a command line option for `--feps`? Or should we have a more general `--additional-treekin-args` option which is passed to Treekin as is?  